### PR TITLE
Overwrite mouseRelease trigger with the same action as mousePressed.

### DIFF
--- a/src/clj/pirates/swingui.clj
+++ b/src/clj/pirates/swingui.clj
@@ -176,12 +176,13 @@
     (if (.isPopupTrigger event) (.show menu component x y))))
 
 (defn clicker [parent game-state]
-  (proxy [MouseAdapter] []
-    (mousePressed [event]
-      (when-let [clicked (get-click-index (-> event .getPoint .x) (-> event .getPoint .y))]
-        (let [player (rules/active-player @game-state)
-              color (key player)]
-          (popup parent event (get-in @game-state [:players color :cards]) game-state color clicked))))))
+  (let [click-handler #(when-let [clicked (get-click-index (-> % .getPoint .x) (-> % .getPoint .y))]
+                        (let [player (rules/active-player @game-state)
+                              color (key player)]
+                          (popup parent % (get-in @game-state [:players color :cards]) game-state color clicked)))]
+    (proxy [MouseAdapter] []
+      (mousePressed [event] (click-handler event))
+      (mouseReleased [event] (click-handler event)))))
 
 (defn c [game-state]
   (let [component (proxy [Component] []


### PR DESCRIPTION
`.isPopupTrigger` is `true` when different events happen depending on the operating system. In Linux and OSX, this is set to `true` when `mousePressed` happens, whereas this happens when `mouseReleased` in Windows.

I created a `click-handler` that can be shared between both triggers. Now everyone can play this game :smile: 
